### PR TITLE
Baseline rescale on super effective DPS

### DIFF
--- a/index.js
+++ b/index.js
@@ -3431,13 +3431,18 @@ function GetPokemonStrongestMovesets(jb_pkm_obj,
                     }
                 }
                 else if (search_mixed && search_type != "Any") { // mixed movesets scale based on search type (super-effective mult)
-                    dps = GetDPS(types, atk, def, hp, 
-                        fm_obj, cm_obj,
-                        (fm_obj.type == mt) ? 1.60 : 1,
-                        (cm_obj.type == mt) ? 1.60 : 1);
-
-                    if (rescale && settings_metric != 'DPS' && settings_metric != 'TDO')
-                        dps /= 1.6;
+                    if (rescale && settings_metric != 'DPS' && settings_metric != 'TDO') {
+                        dps = GetDPS(types, atk, def, hp, 
+                            fm_obj, cm_obj,
+                            (fm_obj.type == mt) ? 1 : 1 / 1.60,
+                            (cm_obj.type == mt) ? 1 : 1 / 1.60);
+                    }
+                    else {
+                        dps = GetDPS(types, atk, def, hp, 
+                            fm_obj, cm_obj,
+                            (fm_obj.type == mt) ? 1.60 : 1,
+                            (cm_obj.type == mt) ? 1.60 : 1);
+                    }
                     tdo = GetTDO(dps, hp, def);
                 }
                 // non-mixed or "anything-goes" searches use traditional dps


### PR DESCRIPTION
When comparing mixed movesets, rescale would change the metric even when both movesets matched because the calculation would pass in a 1.6 multiplier into `GetDPS` and then divide the result by 1.6. This was a good approximation, but `GetDPS` is not a linear transformation and so the result would not be the same (i.e. `GetDPS(..., fm_mult: 1.6) / 1.6 != GetDPS(..., fm_mult: 1)`).

This PR changes the rescale functionality so that rather than pass in a multiplier of 1.6 and then scale the results back down to 1, we instead in use a 1 / 1.6 multiplier for non-matching, non-super effective damage. The result then no longer needs to be scaled back and the super effective damage matches the non-mixed moveset and neutral metrics.

**Example:**
Before the PR, best ice attackers, with and without mixed movesets:
![image](https://github.com/user-attachments/assets/bf28ac8c-2dfe-4e59-a561-4493c734d8d7)
![image](https://github.com/user-attachments/assets/0d81513f-abb8-433f-b817-1b60b2bca2ed)
Note the change in EER for Shadow Mamoswine and Baxcalibur

After the PR, best ice attackers, with and without mixed movesets:
![image](https://github.com/user-attachments/assets/cfb201de-639a-49f1-9a48-e69d6eda0192)
![image](https://github.com/user-attachments/assets/dfa5ab98-3348-4594-b4d8-72179ce0e1f9)
Note that EER stays the same for Shadow Mamoswine and Baxcalibur

EER also now matches the detail page for Shadow Mamoswine (32.41):
![image](https://github.com/user-attachments/assets/a196cd70-ceb1-42ae-85b1-8e88fff1c4da)
