### PR TITLE
Show tiers on mobile

### DIFF
--- a/style_mobile.css
+++ b/style_mobile.css
@@ -187,8 +187,14 @@ body {
         font-size: 14px;
     }
 
+    #strongest-table tr > *:nth-child(1) {
+        width: 10px;
+    }
+
     .tier-label {
-        display: none;
+        font-size: 8px;
+        writing-mode: vertical-lr;
+        transform: scale(-1);
     }
 
     #base-stats tr > *:nth-child(1), #stats-form tr > *:nth-child(1),
@@ -213,5 +219,13 @@ body {
 @media screen and (max-width:400px) { 
     #strongest-table, #strongest-links {
         font-size: 12px;
+    }
+    
+    #strongest-table tr > *:nth-child(1) {
+        width: 5px;
+    }
+
+    .tier-label {
+        font-size: 0;
     }
 }


### PR DESCRIPTION
Updated mobile css to show a thinner tier column instead of hiding it completely.

< 400px will show a thin bar with the colors only and no text.

Example iPhone 12 Pro:
![image](https://github.com/user-attachments/assets/f512107f-056f-4146-b885-c546f56ea9a6)

400px - 800px will show a thinner bar with text rotated 90deg.

Example iPhone 14 Max:
![image](https://github.com/user-attachments/assets/360bd1df-f8fc-4ba9-b45a-f04b64d71bba)
