### PR TITLE
Added tier ranking by attack type table on Pokemon page

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,6 +476,11 @@
                     </ul></td>
                 </tr></tfoot>
             </table>
+            <div class="small-text" id="attack-tiers">
+                <table>
+                    <tbody></tbody>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/rankings.js
+++ b/rankings.js
@@ -29,6 +29,32 @@ function BindRankings() {
     });
 }
 
+/**
+ * Gets the search parameters
+ * The type can be 'each', 'any' or an actual type.
+ */
+function GetSearchParms(type, versus) {
+    let search_params = {
+        versus,
+        type
+    };
+    search_params.unreleased =
+        $("#strongest input[value='unreleased']:checkbox").is(":checked");
+    search_params.mega =
+        $("#strongest input[value='mega']:checkbox").is(":checked");
+    search_params.shadow =
+        $("#strongest input[value='shadow']:checkbox").is(":checked");
+    search_params.legendary =
+        $("#strongest input[value='legendary']:checkbox").is(":checked");
+    search_params.elite =
+        $("#strongest input[value='elite']:checkbox").is(":checked");
+    search_params.suboptimal =
+        $("#strongest input[value='suboptimal']:checkbox").is(":checked");
+    search_params.mixed =
+        $("#strongest input[value='mixed']:checkbox").is(":checked");
+    return search_params;
+}
+
 
 /**
  * Loads the list of the strongest pokemon of a specific type in pokemon go.
@@ -97,25 +123,7 @@ function LoadStrongest(type = "Any") {
     // removes previous table rows
     $("#strongest-table tbody tr").remove();
 
-    // gets checkboxes filters
-    let search_params = {};
-    search_params.unreleased =
-        $("#strongest input[value='unreleased']:checkbox").is(":checked");
-    search_params.mega =
-        $("#strongest input[value='mega']:checkbox").is(":checked");
-    search_params.shadow =
-        $("#strongest input[value='shadow']:checkbox").is(":checked");
-    search_params.legendary =
-        $("#strongest input[value='legendary']:checkbox").is(":checked");
-    search_params.elite =
-        $("#strongest input[value='elite']:checkbox").is(":checked");
-    search_params.suboptimal =
-        $("#strongest input[value='suboptimal']:checkbox").is(":checked");
-    search_params.mixed =
-        $("#strongest input[value='mixed']:checkbox").is(":checked");
-    search_params.versus = 
-        versus_chk.is(":checked");
-    search_params.type = type;
+    const search_params = GetSearchParms(type, versus_chk.is(":checked"));
 
     if (type == "Each") {
         str_pokemons = SetRankingTable(GetStrongestOfEachType(search_params));
@@ -129,7 +137,7 @@ function LoadStrongest(type = "Any") {
                         || settings_metric == 'TER'))
             str_pokemons.forEach(str_pok => str_pok.rat /= 1.6);*/
 
-        ProcessAndGroup(str_pokemons, type);
+        ProcessAndGroup(str_pokemons, type, settings_strongest_count);
         SetRankingTable(str_pokemons, settings_strongest_count, true, true, true);
     }
 
@@ -205,7 +213,7 @@ function GetComparisonMon(str_pokemons) {
  * Group pokemon if needed, with ratings relative to best moveset.
  * Else build tiers and calculate ratings relative to a baseline.
  */
-function ProcessAndGroup(str_pokemons, type) {
+function ProcessAndGroup(str_pokemons, type, strongest_count) {
     const display_grouped = $("#strongest input[value='grouped']:checkbox").is(":checked") 
         && $("#strongest input[value='suboptimal']:checkbox").is(":checked");
         
@@ -213,7 +221,7 @@ function ProcessAndGroup(str_pokemons, type) {
 
     // re-order array based on the optimal movesets of each pokemon
     if (display_grouped) {
-        str_pokemons.length = Math.min(str_pokemons.length, settings_strongest_count); //truncate to top movesets early
+        str_pokemons.length = Math.min(str_pokemons.length, strongest_count); //truncate to top movesets early
 
         let str_pokemons_optimal = new Map(); // map of top movesets per mon
         let rat_order = 0;
@@ -247,7 +255,7 @@ function ProcessAndGroup(str_pokemons, type) {
         }
         BuildTiers(str_pokemons, top_compare, type);
     
-        str_pokemons.length = Math.min(str_pokemons.length, settings_strongest_count); // truncate late so all movesets could be evaluated
+        str_pokemons.length = Math.min(str_pokemons.length, strongest_count); // truncate late so all movesets could be evaluated
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -527,11 +527,30 @@ span.poke-form-name, .poke-number {
     font-size: 1.25em;
 }
 
+#attack-tiers {
+    margin-top: 1em;
+}
+
+#attack-tiers .shadow-icon {
+    width: 16px;
+}
+
+#attack-tiers td { 
+    text-align: left;
+    padding: 2px .5em;
+}
+
+#attack-tiers .type-text {
+    margin-right: 0.5em;
+}
+
+#attack-tiers,
 #effectiveness {
     width: 85%;
     margin-left: 15%;
 }
 
+#attack-tiers a,
 #effectiveness a { cursor: pointer; }
 
 #effectiveness table td, #effectiveness table th {
@@ -539,16 +558,20 @@ span.poke-form-name, .poke-number {
     text-align: left;
 }
 
+#attack-tiers table tr:nth-child(1) td:nth-child(1),
 #effectiveness table tr:nth-child(1) td:nth-child(1) {
     width: 15%;
     text-align: center;
     border: 1px solid var(--col-off);
 }
 
+#attack-tiers table tr:nth-child(1) td:nth-child(2),
 #effectiveness table tr:nth-child(1) td:nth-child(2) {
     border-top: 1px solid var(--col-off);
 }
 
+#attack-tiers table tr:nth-child(1) td:nth-child(2),
+#attack-tiers table tr:not(:nth-child(1)) td:nth-child(1),
 #effectiveness table tr:nth-child(1) td:nth-child(2),
 #effectiveness table tr:not(:nth-child(1)) td:nth-child(1) {
     width: 7.5%;
@@ -558,6 +581,7 @@ span.poke-form-name, .poke-number {
     border-left: 1px solid var(--col-off);
 }
 
+#attack-tiers table tr:nth-last-child(1) td:nth-child(1),
 #effectiveness table tr:nth-child(5) td:nth-child(1) {
     border-bottom: 1px solid var(--col-off);
 }

--- a/style_mobile.css
+++ b/style_mobile.css
@@ -201,7 +201,7 @@ body {
         width: 0%;
     }
 
-    #effectiveness {
+    #attack-tiers, #effectiveness {
         margin-left: 0%;
         width: 100%;
     }


### PR DESCRIPTION
Adds a table that displays the current tier ranking for each type the Pokemon has an attack move for sorted from best to worst.

Preview:
![image](https://github.com/user-attachments/assets/9ecb9302-5349-4859-8a27-d851364705f4)
https://adamhwang.github.io/dialgadex/?p=800&f=Dawn_wings&lvl=40&ivs=151515